### PR TITLE
Tweaks and fixes to shutter walls

### DIFF
--- a/code/__defines/directions.dm
+++ b/code/__defines/directions.dm
@@ -6,7 +6,7 @@
 #define N_NORTHEAST 32
 #define N_NORTHWEST 512
 #define N_SOUTHEAST 64
-#define N_SOUTHWEST 1024 
+#define N_SOUTHWEST 1024
 
 #define CORNER_NONE             0
 #define CORNER_COUNTERCLOCKWISE 1
@@ -42,6 +42,22 @@
 		ret[i] = "[.]"
 
 	return ret
+
+/proc/corner_states_to_dirs(list/corners)
+	if(!istype(corners)) return
+
+	var/list/ret = list(NORTHWEST, SOUTHEAST, NORTHEAST, SOUTHWEST)
+	. = list()
+
+	for(var/i = 1 to ret.len)
+		var/dir = ret[i]
+		var/corner = text2num(corners[i])
+		if(corner & CORNER_DIAGONAL)
+			. |= dir
+		if(corner & CORNER_COUNTERCLOCKWISE)
+			. |= turn(dir, 45)
+		if(corner & CORNER_CLOCKWISE)
+			. |= turn(dir, -45)
 
 // Similar to dirs_to_corner_states(), but returns an *ordered* list, requiring (in order), dir=NORTH, SOUTH, EAST, WEST
 // Note that this means this proc can be used as:

--- a/code/game/turfs/walls/_wall.dm
+++ b/code/game/turfs/walls/_wall.dm
@@ -44,7 +44,9 @@ var/global/list/wall_fullblend_objects = list(
 	var/decl/material/girder_material = /decl/material/solid/metal/steel
 	var/construction_stage
 	var/hitsound = 'sound/weapons/Genhit.ogg'
+	/// A list of connections to walls for each corner, used for icon generation. Can be converted to a list of dirs with corner_states_to_dirs().
 	var/list/wall_connections
+	/// A list of connections to non-walls for each corner, used for icon generation. Can be converted to a list of dirs with corner_states_to_dirs().
 	var/list/other_connections
 	var/floor_type = /turf/floor/plating //turf it leaves after destruction
 	var/paint_color

--- a/code/game/turfs/walls/wall_icon.dm
+++ b/code/game/turfs/walls/wall_icon.dm
@@ -138,6 +138,12 @@
 				I = image(_get_wall_subicon(reinf_material.icon_reinf, wall_connections, reinf_color))
 			add_overlay(I)
 
+// Update icon on ambient light change, for shutter overlays.
+/turf/wall/update_ambient_light_from_z_or_area()
+	. = ..()
+	if(shutter_state)
+		queue_icon_update()
+
 /turf/wall/on_update_icon()
 	. = ..()
 	cut_overlays()
@@ -155,7 +161,10 @@
 	if(!isnull(shutter_state) && shutter_icon)
 		var/decl/material/shutter_mat = shutter_material || material
 		var/list/shutters
+		var/list/connected = corner_states_to_dirs(wall_connections) | corner_states_to_dirs(other_connections) // merge the lists
 		for(var/stepdir in global.cardinal)
+			if(stepdir in connected)
+				continue
 			var/turf/neighbor = get_step_resolving_mimic(src, stepdir)
 			if(!istype(neighbor) || neighbor.density)
 				continue

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -268,6 +268,13 @@
 /obj/item/bedsheet/furs,
 /turf/floor/wood/ebony,
 /area/shaded_hills/stable)
+"jI" = (
+/obj/structure/wall_sconce/lantern{
+	dir = 1;
+	pixel_y = 10
+	},
+/turf/floor/natural/dirt,
+/area/shaded_hills/outside/shrine)
 "ke" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 1;
@@ -659,13 +666,6 @@
 /obj/item/bedsheet/yellowed,
 /turf/floor/wood/ebony,
 /area/shaded_hills/general_store)
-"Ch" = (
-/obj/structure/wall_sconce/lantern{
-	dir = 1;
-	pixel_y = 10
-	},
-/turf/floor/natural/grass,
-/area/shaded_hills/outside/downlands)
 "CR" = (
 /turf/floor/wood/ebony,
 /area/shaded_hills/shrine)
@@ -6017,7 +6017,7 @@ HI
 HI
 HI
 HI
-aU
+TR
 TR
 TR
 Ic
@@ -6321,7 +6321,7 @@ HI
 HI
 HI
 HI
-Ch
+HI
 TR
 EV
 Ic
@@ -18603,7 +18603,7 @@ CR
 pd
 CR
 QB
-kv
+jI
 By
 kv
 kv
@@ -18907,7 +18907,7 @@ CR
 pd
 CR
 QB
-kv
+jI
 kv
 kv
 kv

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -47,8 +47,10 @@
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/shrine)
 "dC" = (
-/obj/structure/door/wood/ebony,
-/turf/floor/natural/path/herringbone/basalt,
+/obj/structure/door/wood/ebony{
+	dir = 4
+	},
+/turf/floor/wood/ebony,
 /area/shaded_hills/inn)
 "dH" = (
 /turf/wall/log/ebony/shutter,
@@ -206,6 +208,12 @@
 /area/shaded_hills/inn)
 "ij" = (
 /obj/structure/bed/chair/wood/ebony{
+	dir = 4
+	},
+/turf/floor/wood/ebony,
+/area/shaded_hills/general_store)
+"iC" = (
+/obj/structure/door/wood/ebony{
 	dir = 4
 	},
 /turf/floor/wood/ebony,
@@ -785,6 +793,12 @@
 "Ic" = (
 /turf/floor/natural/path/running_bond/basalt,
 /area/shaded_hills/outside/downlands)
+"Il" = (
+/obj/structure/door/wood/ebony{
+	dir = 4
+	},
+/turf/floor/wood/ebony,
+/area/shaded_hills/shrine)
 "Im" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 4
@@ -796,7 +810,9 @@
 /turf/wall/brick/basalt,
 /area/shaded_hills/outside/downlands)
 "IL" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/wood/ebony{
+	dir = 4
+	},
 /turf/floor/wood/ebony,
 /area/shaded_hills/tannery)
 "IQ" = (
@@ -817,6 +833,13 @@
 "Jo" = (
 /obj/structure/wall_sconce/lantern,
 /turf/floor/wood/ebony,
+/area/shaded_hills/inn)
+"Jp" = (
+/obj/abstract/landmark/lock_preset/shaded_hills/inn_interior,
+/obj/structure/door/wood/ebony{
+	dir = 4
+	},
+/turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "Jt" = (
 /obj/structure/closet/cabinet/wooden/ebony,
@@ -854,8 +877,7 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "Kh" = (
-/obj/structure/window/basic/full,
-/turf/wall/log/ebony,
+/turf/wall/log/ebony/shutter,
 /area/shaded_hills/shrine)
 "KG" = (
 /obj/structure/railing/mapped/ebony{
@@ -965,6 +987,9 @@
 /obj/structure/railing/mapped/ebony,
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
+"RG" = (
+/turf/wall/brick/basalt/shutter,
+/area/shaded_hills/shrine)
 "RO" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 8
@@ -1015,6 +1040,12 @@
 	},
 /turf/floor/wood/ebony,
 /area/shaded_hills/inn)
+"Ti" = (
+/obj/structure/door/wood/ebony{
+	dir = 4
+	},
+/turf/floor/wood/ebony,
+/area/shaded_hills/farmhouse)
 "Tr" = (
 /obj/structure/table/woodentable_reinforced/ebony,
 /turf/floor/wood/ebony,
@@ -1039,6 +1070,10 @@
 "TR" = (
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/downlands)
+"TZ" = (
+/obj/structure/door/wood/ebony,
+/turf/floor/natural/path/herringbone/basalt,
+/area/shaded_hills/shrine)
 "UD" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/flame/candle,
@@ -9336,7 +9371,7 @@ Wg
 Dn
 yu
 Wg
-eG
+iC
 Wg
 Wg
 HI
@@ -9616,7 +9651,7 @@ TR
 Ee
 Ee
 Ee
-iH
+Jp
 Ee
 Ee
 Ee
@@ -12527,7 +12562,7 @@ TR
 LN
 LN
 LN
-WO
+Ti
 LN
 LN
 TR
@@ -13286,7 +13321,7 @@ VU
 VU
 LN
 LN
-WO
+Ti
 LN
 LN
 LN
@@ -18399,7 +18434,7 @@ By
 iK
 QB
 QB
-AE
+Il
 QB
 CR
 CR
@@ -18553,10 +18588,10 @@ iK
 kv
 kv
 QB
-PG
+Il
 QB
 QB
-PG
+Il
 QB
 QB
 CR
@@ -18719,7 +18754,7 @@ XM
 XM
 XM
 CR
-AE
+PG
 kv
 kv
 kv
@@ -19160,7 +19195,7 @@ kv
 kv
 kv
 kv
-Yc
+RG
 XH
 Vj
 CR
@@ -19312,7 +19347,7 @@ kv
 iK
 kv
 kv
-AE
+TZ
 Vj
 Vj
 TM
@@ -19470,7 +19505,7 @@ CR
 Ot
 bW
 CR
-AE
+PG
 ft
 ft
 ft
@@ -20078,7 +20113,7 @@ uK
 Gb
 Vj
 Vj
-AE
+TZ
 ft
 Zx
 XY


### PR DESCRIPTION
## Description of changes
- Makes wall shutter overlays take into account connections rather than just turf density.
- Replaces glass shrine windows with shutter walls.
- Fixes stray lanterns on the inn map.

## Why and what will this PR improve
Fixes and improvements to the inn map and wall shutters PR.