### PR TITLE
Anima effect expansion

### DIFF
--- a/code/game/objects/effects/fake_fire.dm
+++ b/code/game/objects/effects/fake_fire.dm
@@ -33,17 +33,25 @@
 	if(lifetime)
 		QDEL_IN(src,lifetime)
 
+/obj/effect/fake_fire/proc/can_affect_atom(atom/target)
+	if(target == src)
+		return FALSE
+	return target.simulated
+
+/obj/effect/fake_fire/proc/can_affect_mob(mob/living/victim)
+	return can_affect_atom(victim)
+
 /obj/effect/fake_fire/Process()
 	if(!loc)
 		qdel(src)
 		return PROCESS_KILL
 	for(var/mob/living/victim in loc)
-		if(!victim.simulated)
+		if(!can_affect_mob(victim))
 			continue
 		victim.FireBurn(firelevel, last_temperature, pressure)
 	loc.fire_act(firelevel, last_temperature, pressure)
 	for(var/atom/burned in loc)
-		if(!burned.simulated || burned == src)
+		if(!can_affect_atom(burned))
 			continue
 		burned.fire_act(firelevel, last_temperature, pressure)
 
@@ -53,4 +61,17 @@
 
 /obj/effect/fake_fire/Destroy()
 	STOP_PROCESSING(SSobj,src)
-	. = ..()
+	return ..()
+
+// A subtype of fake_fire used for spells that shouldn't affect the caster.
+/obj/effect/fake_fire/variable/owned
+	var/mob/living/owner
+
+/obj/effect/fake_fire/variable/owned/can_affect_atom(atom/target)
+	if(target == owner)
+		return FALSE
+	return ..()
+
+/obj/effect/fake_fire/variable/owned/Destroy()
+	owner = null
+	return ..()

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -88,7 +88,7 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	do_flash_animation(user, target)
 
-	if(target.stat != DEAD && target.handle_flashed(src, rand(str_min,str_max)))
+	if(target.stat != DEAD && target.handle_flashed(rand(str_min,str_max)))
 		admin_attack_log(user, target, "flashed their victim using \a [src].", "Was flashed by \a [src].", "used \a [src] to flash")
 		if(!target.isSynthetic())
 			user.visible_message(SPAN_DANGER("\The [user] blinds \the [target] with \the [src]!"))
@@ -105,7 +105,7 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	do_flash_animation(user)
 	for(var/mob/living/M in oviewers(3, null))
-		M.handle_flashed(src, rand(str_min,str_max))
+		M.handle_flashed(rand(str_min,str_max))
 	return TRUE
 
 /obj/item/flash/emp_act(severity)
@@ -113,7 +113,7 @@
 		return FALSE
 	do_flash_animation()
 	for(var/mob/living/M in oviewers(3, null))
-		M.handle_flashed(src, rand(str_min,str_max))
+		M.handle_flashed(rand(str_min,str_max))
 
 /obj/item/flash/synthetic //not for regular use, weaker effects
 	name = "modified flash"

--- a/code/game/turfs/floors/natural/natural_mud.dm
+++ b/code/game/turfs/floors/natural/natural_mud.dm
@@ -36,7 +36,9 @@
 	return ..()
 
 /turf/floor/natural/mud/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(!reagents?.total_volume)
+	// scaling taken from /turf/floor/natural/grass/wild/fire_act
+	// smoothly scale between 1/5 chance to scorch at the boiling point of water and 100% chance to scorch at boiling point * 4
+	if(!reagents?.total_volume && temperature >= /decl/material/liquid/water::boiling_point && prob(20 + temperature * 80 / (/decl/material/liquid/water::boiling_point * 4)))
 		ChangeTurf(/turf/floor/natural/dry, keep_air = TRUE, keep_height = TRUE)
 		return
 	return ..()

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -1025,7 +1025,7 @@
 /mob/living/human/proc/post_setup(species_name, datum/mob_snapshot/supplied_appearance)
 	try_refresh_visible_overlays() //Do this exactly once per setup
 
-/mob/living/human/handle_flashed(var/obj/item/flash/flash, var/flash_strength)
+/mob/living/human/handle_flashed(var/flash_strength)
 	var/safety = eyecheck()
 	if(safety < FLASH_PROTECTION_MODERATE)
 		flash_strength = round(get_flash_mod() * flash_strength)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1562,7 +1562,7 @@ default behaviour is:
 /mob/living/proc/handle_footsteps()
 	return
 
-/mob/living/handle_flashed(var/obj/item/flash/flash, var/flash_strength)
+/mob/living/handle_flashed(var/flash_strength)
 
 	var/safety = eyecheck()
 	if(safety >= FLASH_PROTECTION_MODERATE || flash_strength <= 0) // May be modified by human proc.

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -424,7 +424,7 @@
 	if(os)
 		os.Process()
 
-/mob/living/silicon/handle_flashed(var/obj/item/flash/flash, var/flash_strength)
+/mob/living/silicon/handle_flashed(var/flash_strength)
 	SET_STATUS_MAX(src, STAT_PARA, flash_strength)
 	SET_STATUS_MAX(src, STAT_WEAK, flash_strength)
 	return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1192,7 +1192,7 @@
 
 	return FALSE
 
-/mob/proc/handle_flashed(var/obj/item/flash/flash, var/flash_strength)
+/mob/proc/handle_flashed(var/flash_strength)
 	return FALSE
 
 /mob/proc/do_flash_animation()

--- a/mods/content/anima/_anima.dm
+++ b/mods/content/anima/_anima.dm
@@ -4,3 +4,12 @@
 
 /decl/modpack/anima
 	name = "Anima Content"
+	credits_topics = list("ANCIENT MAGIC", "ANCIENT ANIMA", "MAGICAL RITUALS", "MAGIC SPELLS")
+	credits_nouns = list("MAGIC", "ANIMA")
+	credits_adjectives = list("ANCIENT", "MAGICAL", "ARCANE", "DIVINE", "BEWITCHED", "ENCHANTED")
+	credits_crew_outcomes = list("BEWITCHED", "ENCHANTED", "MAGICKED", "CURSED")
+	dreams = list(
+		"anima", "magic", "an ancient curse", "an arcane ritual",
+		"a magic spell", "a magician", "a wizard", "a witch",
+		"a necromancer", "an ancient scroll", "a magic crystal"
+	)

--- a/mods/content/anima/runestones.dm
+++ b/mods/content/anima/runestones.dm
@@ -109,7 +109,7 @@
 	if(!stored_spell?.spell_master)
 		var/decl/material/solid/anima/anima = material
 		if(istype(anima) && anima.undirected_spell?.base_effect)
-			anima.undirected_spell.base_effect.evoke_spell(user, get_turf(user), null)
+			anima.undirected_spell.base_effect.evoke_spell(user, get_turf(user), null, deliberate = deliberate)
 		else
 			new /obj/item/shard(get_turf(user), material?.type)
 		qdel(src)

--- a/mods/content/anima/spell_archetypes.dm
+++ b/mods/content/anima/spell_archetypes.dm
@@ -7,9 +7,7 @@
 	var/arcana_skill = SKILL_SCIENCE
 
 /decl/runestone_spell_archetype/Initialize()
-	for(var/spell_effect in masterwork_effects)
-		masterwork_effects -= spell_effect
-		masterwork_effects |= GET_DECL(spell_effect)
+	masterwork_effects = decls_repository.get_decls_unassociated(masterwork_effects)
 	base_effect = GET_DECL(base_effect)
 	name = base_effect.name
 	return ..()

--- a/mods/content/anima/spell_effect.dm
+++ b/mods/content/anima/spell_effect.dm
@@ -4,7 +4,7 @@
 	var/description
 	var/cost = 1
 
-/decl/anima_spell_effect/proc/evoke_spell(mob/user, atom/target, obj/item/runestone/runestone, caster_effect, caster_strength, in_proximity)
+/decl/anima_spell_effect/proc/evoke_spell(mob/user, atom/target, obj/item/runestone/runestone, caster_effect, caster_strength, in_proximity, deliberate = TRUE)
 	// Get our spell parameters.
 	var/spent_cost     = runestone ? min(runestone.anima_density, cost) : cost
 	var/evoke_effect   = caster_effect   || runestone?.stored_spell?.effect_type || ANIMA_SPELL_AOE
@@ -13,7 +13,7 @@
 	var/evoke_strength = caster_strength || runestone?.anima_density || 1
 
 	// Cast the actual spell.
-	do_evocation(user, target, evoke_effect, evoke_strength)
+	do_evocation(user, target, evoke_effect, evoke_strength, deliberate)
 
 	// Expend resources.
 	if(runestone)
@@ -30,13 +30,13 @@
 /decl/anima_spell_effect/proc/show_primed_message(mob/user, effect_type)
 	to_chat(user, SPAN_NOTICE("Raw anima wreathes your [parse_zone(user.get_active_held_item_slot())], ready to be directed."))
 
-/decl/anima_spell_effect/proc/do_evocation(mob/user, atom/target, evoke_effect = ANIMA_SPELL_AOE, evoke_strength = 1)
+/decl/anima_spell_effect/proc/do_evocation(mob/user, atom/target, evoke_effect = ANIMA_SPELL_AOE, evoke_strength = 1, deliberate = TRUE)
 
 /decl/anima_spell_effect/flash
 	name = "Flash"
 	description = "Release the channeled anima in a blinding flash of light."
 
-/decl/anima_spell_effect/flash/do_evocation(mob/user, atom/target, evoke_effect = ANIMA_SPELL_AOE, evoke_strength = 1)
+/decl/anima_spell_effect/flash/do_evocation(mob/user, atom/target, evoke_effect = ANIMA_SPELL_AOE, evoke_strength = 1, deliberate = TRUE)
 
 	if(evoke_effect == ANIMA_SPELL_AOE)
 		user.visible_message("\The [user] emits a blinding flash of light ([evoke_strength])!")
@@ -48,7 +48,7 @@
 	name = "Gloom"
 	description = "Burn the channeled anima to create a burst of unnatural darkness."
 
-/decl/anima_spell_effect/gloom/do_evocation(mob/user, atom/target, evoke_effect = ANIMA_SPELL_AOE, evoke_strength = 1)
+/decl/anima_spell_effect/gloom/do_evocation(mob/user, atom/target, evoke_effect = ANIMA_SPELL_AOE, evoke_strength = 1, deliberate = TRUE)
 	if(evoke_effect == ANIMA_SPELL_AOE)
 		user.visible_message("\The [user] emits a burst of unnatural darkness ([evoke_strength])!")
 	else
@@ -59,7 +59,7 @@
 	name = "Flare"
 	description = "Release the channeled anima in an undirected burst of flame."
 
-/decl/anima_spell_effect/flare/do_evocation(mob/user, atom/target, evoke_effect = ANIMA_SPELL_AOE, evoke_strength = 1)
+/decl/anima_spell_effect/flare/do_evocation(mob/user, atom/target, evoke_effect = ANIMA_SPELL_AOE, evoke_strength = 1, deliberate = TRUE)
 	if(evoke_effect == ANIMA_SPELL_AOE)
 		user.visible_message("\The [user] is wreathed in a blast of fire! ([evoke_strength])!")
 	else

--- a/mods/content/anima/spellscribing.dm
+++ b/mods/content/anima/spellscribing.dm
@@ -80,7 +80,7 @@
 			return
 		// Refresh spell list for checking.
 		possible_spells = anima_mat.get_cantrips_by_effect_type(user, stored_spell.effect_type)
-		if(!(chosen_spell in possible_spells) || QDELETED(src) || stored_spell || stored_spell.spell_master)
+		if(!(chosen_spell in possible_spells) || QDELETED(src) || stored_spell.spell_master)
 			return
 		to_chat(user, SPAN_NOTICE("You painstakingly etch the runes required to evoke [chosen_spell] onto \the [src]."))
 		stored_spell.spell_master = chosen_spell


### PR DESCRIPTION
- Fixes etching spell effects onto runes, that check just flat-out doesn't work. Maybe it should be `!stored_spell` but there's really no way you can get to that point without one, I think?
- Simplifies the initialisation of the masterwork effect list, by using get_decls_unassociated instead of manual iteration.
- Adds a `deliberate` argument to spell evocation to distinguish between misfires and deliberate AoE spell evocation
- Adds mechanical effects to the placeholder fire anima spells:
  - Targeted Flash blinds a single target with a high severity.
  - AoE Flash blinds many targets with a lower severity.
  - Targeted Flare throws a fireball.
  - AoE Flare creates a fiery blast that doesn't damage the caster.
  - AoE Gloom creates a zone of supernatural darkness.
  - Targeted Gloom blinds a target.
- Adds some silly dream/credit strings to the anima modpack. 😃 

I left the evocation strength messages in for now.

Includes changes from https://github.com/NebulaSS13/Nebula/pull/4330