### PR TITLE
Implement draught multiplier, fix miscellaneous fire source/heater issues

### DIFF
--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -28,22 +28,25 @@
 /atom/proc/get_manual_heat_source_coefficient()
 	return 1
 
+/// Returns the 'ambient temperature' used for temperature equalisation.
+/atom/proc/get_ambient_temperature()
+	if(isturf(loc))
+		return loc.return_air().temperature
+	else if(loc)
+		return loc.temperature
+	// Nullspace is room temperature, clearly.
+	return T20C
+
 // TODO: move mob bodytemperature onto this proc.
 /atom/proc/ProcessAtomTemperature()
 	SHOULD_NOT_SLEEP(TRUE)
 
-	// Get our location temperature if possible.
-	// Nullspace is room temperature, clearly.
-	var/adjust_temp = T20C
+	// Get our ambient temperature if possible.
+	var/adjust_temp = get_ambient_temperature()
 	var/thermal_mass_coefficient = get_thermal_mass_coefficient()
 	if(isturf(loc))
-		var/turf/T = loc
-		var/datum/gas_mixture/environment = T.return_air()
-		adjust_temp = environment.temperature
 		//scale the thermal mass coefficient so that 1atm = 1x, 0atm = 0x, 10atm = 10x
-		thermal_mass_coefficient *= (environment.return_pressure() / ONE_ATMOSPHERE)
-	else if(loc)
-		adjust_temp = loc.temperature
+		thermal_mass_coefficient *= (loc.return_air().return_pressure() / ONE_ATMOSPHERE)
 
 	// Determine if our temperature needs to change.
 	var/old_temp = temperature

--- a/code/game/objects/structures/barrel.dm
+++ b/code/game/objects/structures/barrel.dm
@@ -14,6 +14,7 @@
 	possible_transfer_amounts = @"[10,25,50,100]"
 	volume                    = 7500
 	movable_flags             = MOVABLE_FLAG_WHEELED
+	throwpass                 = TRUE
 
 /obj/structure/reagent_dispensers/barrel/Initialize()
 	..()

--- a/code/game/objects/structures/chemistry/_chemistry.dm
+++ b/code/game/objects/structures/chemistry/_chemistry.dm
@@ -93,6 +93,6 @@
 	. = ..()
 
 /obj/structure/fire_source/heater/take_vaporized_reagent(reagent, amount)
-	if(!vessel)
+	if(!vessel || !vessel.reagents || REAGENTS_FREE_SPACE(vessel.reagents) <= 0)
 		return ..()
 	return vessel.take_vaporized_reagent(reagent, amount)

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -33,6 +33,7 @@
 		"one-quarter closed"    = 0.75,
 		"half closed"           = 0.5,
 		"three-quarters closed" = 0.25,
+		"open just a crack"     = 0.1,
 		"all the way closed"    = 0
 	)
 	var/current_draught = 1

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -395,6 +395,11 @@
 		return ..() // just normal room temperature
 	return get_effective_burn_temperature() // heat up to our burn temperature
 
+/obj/structure/fire_source/ProcessAtomTemperature()
+	. = ..()
+	if(lit == FIRE_LIT)
+		return null // Don't return PROCESS_KILL here, we want to keep the fire going
+
 /obj/structure/fire_source/Process()
 
 	if(lit != FIRE_LIT)

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -410,7 +410,7 @@
 		die()
 		return
 
-	fuel -= FUEL_CONSUMPTION_CONSTANT
+	fuel -= (FUEL_CONSUMPTION_CONSTANT * get_draught_multiplier())
 	if(!process_fuel())
 		die()
 		return

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -57,7 +57,7 @@
 	// TODO: Replace this and the fuel var with just tracking currently-burning matter?
 	// Or use atom fires when those are implemented?
 	/// The minimum temperature required to ignite any fuel added.
-	var/last_fuel_ignite_temperature = 0
+	var/last_fuel_ignite_temperature
 	var/cap_last_fuel_burn = 850 CELSIUS // Prevent using campfires and stoves as kilns.
 	var/exterior_temperature = 30
 
@@ -138,7 +138,7 @@
 /obj/structure/fire_source/proc/die()
 	if(lit == FIRE_LIT)
 		lit = FIRE_DEAD
-		last_fuel_ignite_temperature = 0
+		last_fuel_ignite_temperature = null
 		last_fuel_burn_temperature = T20C
 		refresh_affected_exterior_turfs()
 		visible_message(SPAN_DANGER("\The [src] goes out!"))
@@ -185,7 +185,7 @@
 	if(distance <= 1)
 		if(has_draught)
 			to_chat(user, "\The [src]'s draught is [draught_values[current_draught]].")
-		var/list/burn_strings = get_descriptive_temperature_strings(last_fuel_burn_temperature)
+		var/list/burn_strings = get_descriptive_temperature_strings(get_effective_burn_temperature())
 		if(length(burn_strings))
 			to_chat(user, "\The [src] is burning hot enough to [english_list(burn_strings)].")
 		var/list/removable = get_removable_atoms()
@@ -206,7 +206,7 @@
 			if(lit == FIRE_LIT)
 				visible_message(SPAN_DANGER("\The [user] fishes \the [removing] out of \the [src]!"))
 				// Uncomment this when there's a way to take stuff out of a kiln or oven without setting yourself on fire.
-				//user.fire_act(return_air(), last_fuel_burn_temperature, 500)
+				//user.fire_act(return_air(), get_effective_burn_temperature(), 500)
 			else
 				visible_message(SPAN_NOTICE("\The [user] removes \the [removing] from \the [src]."))
 		update_icon()
@@ -234,7 +234,7 @@
 	SET_STATUS_MAX(affecting_mob, STAT_WEAK, 5)
 	visible_message(SPAN_DANGER("\The [G.assailant] hurls \the [affecting_mob] onto \the [src]!"))
 	if(lit == FIRE_LIT)
-		affecting_mob.fire_act(return_air(), last_fuel_burn_temperature, 500)
+		affecting_mob.fire_act(return_air(), get_effective_burn_temperature(), 500)
 	return TRUE
 
 /obj/structure/fire_source/isflamesource()
@@ -244,17 +244,21 @@
 	return ..() || (istype(mover) && mover.checkpass(PASS_FLAG_TABLE))
 
 /obj/structure/fire_source/proc/burn_material(var/decl/material/mat, var/amount)
-	. = mat.get_burn_products(amount, last_fuel_burn_temperature)
+	var/effective_burn_temperature = get_effective_burn_temperature()
+	. = mat.get_burn_products(amount, effective_burn_temperature)
 	if(.)
-		if(mat.ignition_point && last_fuel_burn_temperature >= mat.ignition_point)
+		if(mat.ignition_point && effective_burn_temperature >= mat.ignition_point)
 			if(mat.accelerant_value > FUEL_VALUE_NONE)
 				fuel += amount * (1 + material.accelerant_value)
 			last_fuel_burn_temperature = max(last_fuel_burn_temperature, mat.burn_temperature)
-			last_fuel_ignite_temperature = min(last_fuel_ignite_temperature, mat.ignition_point)
+			if(isnull(last_fuel_ignite_temperature))
+				last_fuel_ignite_temperature = mat.ignition_point
+			else
+				last_fuel_ignite_temperature = max(last_fuel_ignite_temperature, mat.ignition_point)
 		else if(mat.accelerant_value <= FUEL_VALUE_SUPPRESSANT)
 			fuel -= amount * mat.accelerant_value
 		fuel = max(fuel, 0)
-		loc.take_waste_burn_products(., last_fuel_burn_temperature)
+		loc.take_waste_burn_products(., effective_burn_temperature)
 
 // Dump waste gas from burned fuel.
 /obj/structure/fire_source/proc/dump_waste_products(var/atom/target, var/list/waste)
@@ -281,7 +285,7 @@
 				return TRUE
 
 	if(lit == FIRE_LIT && istype(thing, /obj/item/flame))
-		thing.fire_act(return_air(), last_fuel_burn_temperature, 500)
+		thing.fire_act(return_air(), get_effective_burn_temperature(), 500)
 		return TRUE
 
 	if(thing.isflamesource())
@@ -301,9 +305,11 @@
 
 	return ..()
 
-/obj/structure/fire_source/proc/process_fuel(ignition_temperature)
+/obj/structure/fire_source/proc/get_draught_multiplier()
+	return has_draught ? draught_values[draught_values[current_draught]] : 1
 
-	var/draught_mult = (has_draught ? draught_values[draught_values[current_draught]] : 1)
+/obj/structure/fire_source/proc/process_fuel(ignition_temperature)
+	var/draught_mult = get_draught_multiplier()
 	if(draught_mult <= 0)
 		return FALSE
 
@@ -313,9 +319,12 @@
 	// Slowly lose burn temperature.
 	// TODO: use temperature var and equalizing system?
 	last_fuel_burn_temperature = max(ignition_temperature, last_fuel_burn_temperature)
+	var/effective_burn_temperature = get_effective_burn_temperature()
 	if(fuel < LOW_FUEL) // fire's dying
-		if(last_fuel_burn_temperature > T20C)
+		if(effective_burn_temperature > T20C)
 			last_fuel_burn_temperature = max(T20C, round(last_fuel_burn_temperature * 0.95))
+			effective_burn_temperature = get_effective_burn_temperature()
+		// Just to avoid accidentally snuffing it with the draught, we don't check effective temperature here
 		if(last_fuel_burn_temperature < last_fuel_ignite_temperature)
 			return FALSE // kill the fire, too cold to burn additional fuel
 
@@ -336,8 +345,7 @@
 	dump_waste_products(loc, waste)
 
 	if(!isnull(cap_last_fuel_burn))
-		var/effective_cap = cap_last_fuel_burn * draught_mult
-		last_fuel_burn_temperature = min(last_fuel_burn_temperature, effective_cap)
+		last_fuel_burn_temperature = min(last_fuel_burn_temperature, cap_last_fuel_burn)
 		// TODO: dump excess directly into the atmosphere as heat
 
 	return (fuel > 0)
@@ -370,6 +378,23 @@
 /obj/structure/fire_source/proc/get_fire_exposed_atoms()
 	return loc?.get_contained_external_atoms()
 
+/obj/structure/fire_source/proc/get_effective_burn_temperature()
+	if(lit != FIRE_LIT)
+		return 0
+	var/draught_mult = get_draught_multiplier()
+	if(draught_mult <= 0)
+		return 0
+	var/ambient_temperature = get_ambient_temperature(absolute = TRUE)
+	// The effective burn temperature can't go below ambient (no cold flames) or above the actual burn temperature.
+	return clamp(last_fuel_burn_temperature * draught_mult, ambient_temperature, last_fuel_burn_temperature)
+
+// If absolute == TRUE, return our actual ambient temperature, otherwise return our effective burn temperature when lit.
+/obj/structure/fire_source/get_ambient_temperature(absolute = FALSE)
+	. = ..()
+	if(absolute || lit != FIRE_LIT)
+		return ..() // just normal room temperature
+	return get_effective_burn_temperature() // heat up to our burn temperature
+
 /obj/structure/fire_source/Process()
 
 	if(lit != FIRE_LIT)
@@ -384,20 +409,22 @@
 		die()
 		return
 
+	var/effective_burn_temperature = get_effective_burn_temperature()
+
 	if(isturf(loc))
 		var/turf/my_turf = loc
-		my_turf.hotspot_expose(last_fuel_burn_temperature, 500, 1)
+		my_turf.hotspot_expose(effective_burn_temperature, 500, 1)
 
 	var/datum/gas_mixture/environment = return_air()
 	for(var/atom/thing in get_fire_exposed_atoms())
-		thing.fire_act(environment, last_fuel_burn_temperature, 500)
+		thing.fire_act(environment, effective_burn_temperature, 500)
 
 	// Copied from space heaters. Heat up the air on our tile, heat will percolate out.
-	if(environment && abs(environment.temperature - last_fuel_burn_temperature) > 0.1)
+	if(environment && abs(environment.temperature - effective_burn_temperature) > 0.1)
 		var/transfer_moles = 0.25 * environment.total_moles
 		var/datum/gas_mixture/removed = environment.remove(transfer_moles)
 		if(removed)
-			var/heat_transfer = removed.get_thermal_energy_change(round(last_fuel_burn_temperature * 0.1))
+			var/heat_transfer = removed.get_thermal_energy_change(round(effective_burn_temperature * 0.1))
 			if(heat_transfer > 0)
 				removed.add_thermal_energy(heat_transfer)
 		environment.merge(removed)

--- a/code/js/view_variables.js
+++ b/code/js/view_variables.js
@@ -17,6 +17,11 @@ function updateSearch() {
 	}
 }
 
+function refreshPage(datumref) {
+	window.location.href = 'byond://?_src_=vars;datumrefresh=' + encodeURIComponent(datumref) + ';filter=' + encodeURIComponent(document.getElementById('filter').value);
+	return true;
+}
+
 function selectTextField() {
 	var filter_text = document.getElementById('filter');
 	filter_text.focus();

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -693,6 +693,6 @@
 	if(href_list["datumrefresh"])
 		var/datum/datum_to_refresh = locate(href_list["datumrefresh"])
 		if(istype(datum_to_refresh, /datum) || istype(datum_to_refresh, /client))
-			debug_variables(datum_to_refresh)
+			debug_variables_inner(datum_to_refresh, filter = href_list["filter"])
 
 	return

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -8,6 +8,9 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 	set category = "Debug"
 	set name = "View Variables"
 
+	debug_variables_inner(D)
+
+/client/proc/debug_variables_inner(datum/D, filter = "" as null|text)
 	if(!check_rights(R_VAREDIT | R_DEBUG))
 		return
 
@@ -49,7 +52,7 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 					</td>
 					<td width='50%'>
 						<div align='center'>
-							<a href='byond://?_src_=vars;datumrefresh=\ref[D]'>Refresh</a>
+							<a href='javascript:void(0)' onClick='refreshPage(\"\ref[D]\")'>Refresh</a>
 							[A ? "<A HREF='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[A.x];Y=[A.y];Z=[A.z]'>Jump To</a>":""]
 							<form>
 								<select name='file'
@@ -86,7 +89,7 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 					<input type='text'
 					       id='filter'
 					       name='filter_text'
-					       value=''
+					       value='[filter]'
 					       style='width:100%;' />
 				</td>
 			</tr></table>

--- a/code/modules/reagents/chems/chems_ethanol.dm
+++ b/code/modules/reagents/chems/chems_ethanol.dm
@@ -9,8 +9,10 @@
 	solvent_power = MAT_SOLVENT_MODERATE
 	uid = "chem_ethanol"
 
-	heating_message = "boils away its water content, leaving pure ethanol."
-	heating_point = T100C + 10
+	boiling_point = T0C + 78.37
+
+	heating_message = "boils away its ethanol content, leaving pure water."
+	heating_point = T0C + 78.37
 	heating_products = list(
 		/decl/material/liquid/ethanol = 0.75,
 		/decl/material/liquid/water =   0.25
@@ -18,10 +20,10 @@
 	bypass_heating_products_for_root_type = /decl/material/liquid/ethanol
 
 	chilling_message = "separates as its water content freezes, leaving pure ethanol."
-	chilling_point = T0C - 10
+	chilling_point = T0C
 	chilling_products = list(
 		/decl/material/liquid/ethanol = 0.75,
-		/decl/material/liquid/water =   0.25
+		/decl/material/solid/ice =      0.25
 	)
 	bypass_chilling_products_for_root_type = /decl/material/liquid/ethanol
 	affect_blood_on_ingest = FALSE // prevents automatic toxins/inebriation as though injected
@@ -35,6 +37,12 @@
 	glass_name = "ethanol"
 	glass_desc = "A well-known alcohol with a variety of applications."
 	value = 1.2
+
+/decl/material/liquid/ethanol/Initialize()
+	. = ..()
+	// Impure ethanol doesn't boil, it has to separate first.
+	if(type != bypass_heating_products_for_root_type)
+		boiling_point = null
 
 /decl/material/liquid/ethanol/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()


### PR DESCRIPTION
Implements draught multiplier, adds throwpass to barrels, **makes refreshing VV not clear the search filter** (very useful for testing this PR), adds a boiling point to ethanol (and adjusts the chilling/heating points), fixes an infinite recursion in take_vaporized_reagent, splits up ProcessAtomTemperature, fixes fire sources prematurely ending their temperature processing, stops fire sources from being chilled by their loc, adds a 10% draught level, and adjusts fuel consumption based on the draught multiplier.